### PR TITLE
Fix TypeError: Argument 1 passed to SplFileInfo::__construct() must be of the type string, bool given

### DIFF
--- a/src/PHPFinder.php
+++ b/src/PHPFinder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PHPMND;
 
-use function array_diff;
 use function array_filter;
 use function array_map;
 use function array_merge;
@@ -24,7 +23,7 @@ class PHPFinder extends Finder
     ) {
         parent::__construct();
         $dirs = array_filter($directories, 'is_dir');
-        $files = array_diff($directories, $dirs);
+        $files = array_filter($directories, 'is_file');
 
         $this
             ->files()

--- a/tests/Command/RunCommandTest.php
+++ b/tests/Command/RunCommandTest.php
@@ -66,5 +66,6 @@ class RunCommandTest extends TestCase
         ]);
 
         $this->assertSame(RunCommand::SUCCESS, $this->commandTester->getStatusCode());
+        $this->assertRegExp('/No files found to scan/i', $this->commandTester->getDisplay());
     }
 }

--- a/tests/Command/RunCommandTest.php
+++ b/tests/Command/RunCommandTest.php
@@ -57,4 +57,14 @@ class RunCommandTest extends TestCase
         $this->assertSame(RunCommand::FAILURE, $this->commandTester->getStatusCode());
         $this->assertRegExp('/Suggestions:/i', $this->commandTester->getDisplay());
     }
+
+    public function test_it_does_not_fail_command_when_file_on_path_does_not_exist(): void
+    {
+        $this->commandTester->execute([
+            'directories' => ['tests/Fixtures/FILE_DOES_NOT_EXIST.php'],
+            '--extensions' => 'all',
+        ]);
+
+        $this->assertSame(RunCommand::SUCCESS, $this->commandTester->getStatusCode());
+    }
 }


### PR DESCRIPTION
This PR fixes:
```bash
TypeError: Argument 1 passed to Symfony\Component\Finder\SplFileInfo::__construct() must be of the type string, bool given
```

For case when file does not exist in path (look at test case to get more details)