### PR TITLE
[BC Break] Return non zero exit code on magic number detection. Remove --non-zero-exit-on-violation option

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -103,12 +103,6 @@ class RunCommand extends BaseCommand
                 'Show progress bar'
             )
             ->addOption(
-                'non-zero-exit-on-violation',
-                null,
-                InputOption::VALUE_NONE,
-                'Return a non zero exit code when there are magic numbers'
-            )
-            ->addOption(
                 'strings',
                 null,
                 InputOption::VALUE_NONE,
@@ -207,11 +201,7 @@ class RunCommand extends BaseCommand
             $output->writeln('<info>' . $this->getResourceUsage() . '</info>');
         }
 
-        if ($input->getOption('non-zero-exit-on-violation') && $fileReportList->hasMagicNumbers()) {
-            return self::FAILURE;
-        }
-
-        return self::SUCCESS;
+        return $fileReportList->hasMagicNumbers() ? self::FAILURE : self::SUCCESS;
     }
 
     protected function createFinder(InputInterface $input): PHPFinder

--- a/tests/Command/RunCommandTest.php
+++ b/tests/Command/RunCommandTest.php
@@ -39,7 +39,6 @@ class RunCommandTest extends TestCase
     {
         $this->commandTester->execute([
             'directories' => ['tests/Fixtures'],
-            '--non-zero-exit-on-violation' => true,
         ]);
 
         $this->assertSame(RunCommand::FAILURE, $this->commandTester->getStatusCode());


### PR DESCRIPTION
This PR removes `--non-zero-exit-on-violation` option as mostly `phpmnd` is a part of CI pipeline where we need to fail build in case magic number is detected. (this change won't affect local development)

I don't see any reason to have this option. I don't think that anybody uses `phpmnd` without `--non-zero-exit-on-violation`.