### PR TITLE
Update php-parallel-lint/php-console-highlighter to get rid of abandoned extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^7.1 || ^8.0",
         "composer/xdebug-handler": "^1.3.3",
         "nikic/php-parser": "^4.0",
-        "php-parallel-lint/php-console-highlighter": "^0.4",
+        "php-parallel-lint/php-console-highlighter": "^0.5.0",
         "phpunit/php-timer": "^2.0 || ^3.0 || ^4.0 || ^5.0",
         "symfony/console": "^4.0 || ^5.0",
         "symfony/finder": "^4.0 || ^5.0"


### PR DESCRIPTION
Update `php-parallel-lint/php-console-highlighter` to get rid of abandoned extension